### PR TITLE
Version 1.2

### DIFF
--- a/com.indomitusgroup.indipdf.yml
+++ b/com.indomitusgroup.indipdf.yml
@@ -10,6 +10,8 @@ finish-args:
   - --socket=fallback-x11
   - --share=ipc
   - --socket=cups
+  # Network access for downloading OCR language data on first use
+  - --share=network
   # Device access for GPU (dri) and scanners (USB)
   - --device=all
   # Write access to common locations for saving PDFs
@@ -83,6 +85,56 @@ modules:
         url: https://github.com/OpenPrinting/cups/releases/download/v2.4.11/cups-2.4.11-source.tar.gz
         sha256: 9a88fe1da3a29a917c3fc67ce6eb3178399d68e1a548c6d86c70d9b13651fd71
 
+  # Ghostscript for PDF compression and PDF/A export
+  - name: ghostscript
+    buildsystem: autotools
+    build-options:
+      cflags: '-std=gnu11'
+    config-opts:
+      - --prefix=/app
+      - --disable-cups
+      - --disable-dbus
+      - --disable-gtk
+      - --without-x
+      - --without-tesseract
+      - --with-drivers=FILES
+    cleanup:
+      - /share/doc
+      - /share/man
+      - /share/ghostscript
+      - /include
+      - /lib/*.a
+      - /lib/*.la
+      - /lib/pkgconfig
+    sources:
+      - type: archive
+        url: https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs10040/ghostscript-10.04.0.tar.gz
+        sha256: c764dfbb7b13fc71a7a05c634e014f9bb1fb83b899fe39efc0b6c3522a9998b1
+      - type: shell
+        commands:
+          - rm -rf jpeg libpng tiff zlib openjpeg
+
+  # qpdf for PDF encryption/decryption
+  - name: qpdf
+    buildsystem: cmake-ninja
+    builddir: true
+    build-options:
+      cxxflags: '-include cstdint'
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DREQUIRE_CRYPTO_OPENSSL=ON
+      - -DBUILD_STATIC_LIBS=OFF
+    cleanup:
+      - /share/doc
+      - /share/man
+      - /include
+      - /lib/*.a
+      - /lib/pkgconfig
+    sources:
+      - type: archive
+        url: https://github.com/qpdf/qpdf/releases/download/v11.9.1/qpdf-11.9.1.tar.gz
+        sha256: 2ba4d248f9567a27c146b9772ef5dc93bd9622317978455ffe91b259340d13d1
+
   - name: indipdf
     buildsystem: simple
     build-commands:
@@ -96,5 +148,5 @@ modules:
       - install -Dm644 icons/512x512.png ${FLATPAK_DEST}/share/icons/hicolor/512x512/apps/com.indomitusgroup.indipdf.png
     sources:
       - type: archive
-        url: https://downloads.indomitusgroup.com/indipdf/indipdf-1.1.0-linux-x86_64.tar.gz
-        sha256: 4599ca48c83d72ff1dc5608be5539add40f1f38fa97f28c5a4c2aa11187597bd
+        url: https://downloads.indomitusgroup.com/indipdf/indipdf-1.2.0-linux-x86_64.tar.gz
+        sha256: 68b28f40134af2c35a3b8d6c1a05ce0444dfa38669fafbbc3efba10e1493f0d2


### PR DESCRIPTION
Asks for network access to properly initialize tesseract.js for OCR text recognition.